### PR TITLE
fix bug to flash errors for users instead of breaking page

### DIFF
--- a/app/services/adjust_sku_service.rb
+++ b/app/services/adjust_sku_service.rb
@@ -2,24 +2,19 @@ class AdjustSkuService
 
 	def update_subscription(old_sku, new_sku)
     variant1 = Spree::Variant.find_by(sku: old_sku)
-
-    begin
-      variant2 = Spree::Variant.find_by(sku: new_sku)
-      subscriptions = []
-      subscription_items = Spree::SubscriptionItem.where(variant_id: variant1.id)
-      for item in subscription_items
-        subscription = item.subscription
-        subscription.subscription_items.create!(
-          variant_id: variant2.id, quantity: item.quantity, price: item.price, cost_price: item.cost_price, \
-          tax_category_id: item.tax_category_id, adjustment_total: item.adjustment_total, additional_tax_total: item.additional_tax_total, \
-          promo_total: item.promo_total, included_tax_total: item.included_tax_total, pre_tax_amount: item.pre_tax_amount, interval: item.interval)
-        subscription_items.delete(item)
-        subscriptions << item.subscription
-      end
-      subscriptions
+    variant2 = Spree::Variant.find_by(sku: new_sku)
+    subscriptions = []
+    subscription_items = Spree::SubscriptionItem.where(variant_id: variant1.id)
+    for item in subscription_items
+      subscription = item.subscription
+      subscription.subscription_items.create!(
+        variant_id: variant2.id, quantity: item.quantity, price: item.price, cost_price: item.cost_price, \
+        tax_category_id: item.tax_category_id, adjustment_total: item.adjustment_total, additional_tax_total: item.additional_tax_total, \
+        promo_total: item.promo_total, included_tax_total: item.included_tax_total, pre_tax_amount: item.pre_tax_amount, interval: item.interval)
+      subscription_items.delete(item)
+      subscriptions << item.subscription
     end
-    rescue => error
-      error
-    end
+    subscriptions
+  end
 
 end

--- a/spec/services/adjust_sku_service_spec.rb
+++ b/spec/services/adjust_sku_service_spec.rb
@@ -59,8 +59,8 @@ describe AdjustSkuService do
 
   it "the variant of the new sku must exist" do
     @subscription.subscription_items.create!(variant_id: @old_variant.id, quantity: 5, price: 10.00, interval: 2)
-    AdjustSkuService.new.update_subscription("bdc1", "bdc3")
 
+    expect{ AdjustSkuService.new.update_subscription("bdc1", "bdc3") }.to raise_error
     expect(@subscription.subscription_items.first).to have_attributes(variant_id: @old_variant.id)
   end
 


### PR DESCRIPTION
@bryanmtl 
fixed the bug where the page was breaking instead of flashing errors to users - did it in the glossier project rather than my forked one because my forked version has been a pain lately