### PR TITLE
admin users can click on the associated credit card of a subscription

### DIFF
--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -81,6 +81,7 @@ module Spree
 
       # creates a new credit card and attaches it to the subscription
       def credit_card
+        @order = @object.orders.last
         if request.post?
           begin
             # get the payment_method_id


### PR DESCRIPTION
@bryanmtl 
admin users are now able to click on the associated credit card of a subscription to edit the credit card.

the process of actually updating the credit card locally doesn't work, and i think it's because the gateway customer stuff is setup different in development, i'm thinking of trying to get this into production and seeing what happens, i don't have another idea of testing that it's working properly - open to suggestions