### PR TITLE
Fix update subscription address

### DIFF
--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -37,6 +37,17 @@ module Spree
         end
       end
 
+      def update
+        UpdateSubscriptionAddress.new.update_address(@object, params[:subscription])
+        if @subscription.save
+          flash[:success] = flash_message_for(@subscription, :subscription_address_updated)
+
+          redirect_to edit_object_url(@subscription)
+        else
+          flash[:error] = Spree.t(:subscription_address_could_not_be_update)
+        end
+      end
+
       def renew
         before_failure_count = @object.failure_count
         ::GenerateSubscriptionOrder.new(@object).call

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -41,11 +41,11 @@ module Spree
         if params[:subscription].key?(:ship_address_attributes || :bill_address_attributes)
           UpdateSubscriptionAddress.new.update_address(@object, params[:subscription])
           if @subscription.save
-            flash.notice = "Subscription #{@subscription.id}'s address was successfully updated"
+            flash[:success] = "Subscription address was successfully updated"
 
             redirect_to edit_object_url(@subscription)
           else
-            flash[:error] = "Subscription #{@subscription.id}'s address could not be updated: #{error.message}"
+            flash[:error] = "Subscription address could not be updated: #{error.message}"
           end
         end
       end

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -38,13 +38,15 @@ module Spree
       end
 
       def update
-        UpdateSubscriptionAddress.new.update_address(@object, params[:subscription])
-        if @subscription.save
-          flash[:success] = flash_message_for(@subscription, :subscription_address_updated)
+        if params[:subscription].key?(:ship_address_attributes || :bill_address_attributes)
+          UpdateSubscriptionAddress.new.update_address(@object, params[:subscription])
+          if @subscription.save
+            flash.notice = "Subscription #{@subscription.id}'s address was successfully updated"
 
-          redirect_to edit_object_url(@subscription)
-        else
-          flash[:error] = Spree.t(:subscription_address_could_not_be_update)
+            redirect_to edit_object_url(@subscription)
+          else
+            flash[:error] = "Subscription #{@subscription.id}'s address could not be updated: #{error.message}"
+          end
         end
       end
 

--- a/app/jobs/create_subscription_job.rb
+++ b/app/jobs/create_subscription_job.rb
@@ -2,7 +2,7 @@ class CreateSubscriptionJob < ActiveJob::Base
   queue_as :default
 
   def perform(order_id)
-    begin      
+    begin
       order = Spree::Order.find(order_id)
       create_subscription_from_eligible_items(order)
     rescue => e
@@ -14,7 +14,7 @@ class CreateSubscriptionJob < ActiveJob::Base
 protected
 
   def create_subscription_from_eligible_items(order)
-    user = Spree::User.find_by_email(order.email)
+    user = order.user
     line_items = eligible_line_items(order)
     line_items.keys.each do |interval|
       attrs = {

--- a/app/models/spree/subscription_address.rb
+++ b/app/models/spree/subscription_address.rb
@@ -1,7 +1,11 @@
 module Spree
   class SubscriptionAddress < Spree::Address
-    self.table_name = 'spree_subscription_addresses'  
+    self.table_name = 'spree_subscription_addresses'
 
     belongs_to :user
+
+    def readonly?
+      false
+    end
   end
 end

--- a/app/services/update_subscription_address.rb
+++ b/app/services/update_subscription_address.rb
@@ -1,0 +1,28 @@
+class UpdateSubscriptionAddress
+
+  def update_address(subscription, subscription_params)
+    new_ship_address = subscription_params[:ship_address_attributes]
+    new_bill_address = subscription_params[:bill_address_attributes]
+
+    if (subscription.ship_address != new_ship_address) && (subscription.bill_address == new_bill_address)
+      update_ship_address(subscription, new_ship_address)
+    elsif (subscription.bill_address != new_bill_address) && (subscription.ship_address == new_ship_address)
+      update_bill_address(subscription, new_bill_address)
+    elsif (subscription.ship_address != new_ship_address) && (subscription.bill_address != new_bill_address)
+      update_ship_and_bill_address(subscription, new_ship_address, new_bill_address)
+    end
+  end
+
+  def update_ship_address(subscription, new_ship_address)
+    subscription.build_ship_address(subscription.ship_address.dup.attributes.merge(new_ship_address))
+  end
+
+  def update_bill_address(subscription, new_bill_address)
+    subscription.build_bill_address(subscription.bill_address.dup.attributes.merge(new_bill_address)))
+  end
+
+  def update_ship_and_bill_address(subscription, new_ship_address, new_bill_address)
+    update_ship_address(subscription, new_ship_address)
+    update_bill_address(subscription, new_bill_address)
+  end
+end

--- a/app/services/update_subscription_address.rb
+++ b/app/services/update_subscription_address.rb
@@ -18,7 +18,7 @@ class UpdateSubscriptionAddress
   end
 
   def update_bill_address(subscription, new_bill_address)
-    subscription.build_bill_address(subscription.bill_address.dup.attributes.merge(new_bill_address)))
+    subscription.build_bill_address(subscription.bill_address.dup.attributes.merge(new_bill_address))
   end
 
   def update_ship_and_bill_address(subscription, new_ship_address, new_bill_address)

--- a/app/services/update_subscription_address.rb
+++ b/app/services/update_subscription_address.rb
@@ -4,14 +4,10 @@ class UpdateSubscriptionAddress
     new_ship_address = subscription_params[:ship_address_attributes]
     new_bill_address = subscription_params[:bill_address_attributes]
 
-    if (subscription.ship_address != new_ship_address) && (subscription.bill_address == new_bill_address)
-      update_ship_address(subscription, new_ship_address)
-    elsif (subscription.bill_address != new_bill_address) && (subscription.ship_address == new_ship_address)
-      update_bill_address(subscription, new_bill_address)
-    elsif (subscription.ship_address != new_ship_address) && (subscription.bill_address != new_bill_address)
-      update_ship_and_bill_address(subscription, new_ship_address, new_bill_address)
-    end
+    update_ship_address(subscription, new_ship_address) if subscription.ship_address != new_ship_address
+    update_bill_address(subscription, new_bill_address) if subscription.bill_address != new_bill_address
   end
+
 
   def update_ship_address(subscription, new_ship_address)
     subscription.ship_address.update_columns(new_ship_address)
@@ -21,8 +17,4 @@ class UpdateSubscriptionAddress
     subscription.bill_address.update_columns(new_bill_address)
   end
 
-  def update_ship_and_bill_address(subscription, new_ship_address, new_bill_address)
-    update_ship_address(subscription, new_ship_address)
-    update_bill_address(subscription, new_bill_address)
-  end
 end

--- a/app/services/update_subscription_address.rb
+++ b/app/services/update_subscription_address.rb
@@ -14,11 +14,11 @@ class UpdateSubscriptionAddress
   end
 
   def update_ship_address(subscription, new_ship_address)
-    subscription.create_ship_address!(subscription.ship_address.dup.attributes.merge(new_ship_address))
+    subscription.ship_address.update_columns(new_ship_address)
   end
 
   def update_bill_address(subscription, new_bill_address)
-    subscription.create_bill_address!(subscription.bill_address.dup.attributes.merge(new_bill_address))
+    subscription.bill_address.update_columns(new_bill_address)
   end
 
   def update_ship_and_bill_address(subscription, new_ship_address, new_bill_address)

--- a/app/services/update_subscription_address.rb
+++ b/app/services/update_subscription_address.rb
@@ -14,11 +14,11 @@ class UpdateSubscriptionAddress
   end
 
   def update_ship_address(subscription, new_ship_address)
-    subscription.build_ship_address(subscription.ship_address.dup.attributes.merge(new_ship_address))
+    subscription.create_ship_address!(subscription.ship_address.dup.attributes.merge(new_ship_address))
   end
 
   def update_bill_address(subscription, new_bill_address)
-    subscription.build_bill_address(subscription.bill_address.dup.attributes.merge(new_bill_address))
+    subscription.create_bill_address!(subscription.bill_address.dup.attributes.merge(new_bill_address))
   end
 
   def update_ship_and_bill_address(subscription, new_ship_address, new_bill_address)

--- a/spec/models/spree/subscription_address.rb
+++ b/spec/models/spree/subscription_address.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Spree::SubscriptionAddress do
+
+  let(:subscription_address) { create(:subscription_address) }
+
+  it "is not readonly" do
+    expect(subscription_address.readonly?).to be(false)
+  end
+end

--- a/spec/requests/admin/subscription_spec.rb
+++ b/spec/requests/admin/subscription_spec.rb
@@ -28,26 +28,14 @@ feature 'Subscription' do
       click_link("Edit", visible: false)
 
       fill_in("subscription_bill_address_attributes_address1", with: "updated address 1")
-      fill_in("subscription_bill_address_attributes_address2", with: "updated address 2")
-      fill_in("subscription_bill_address_attributes_city", with: "updated city")
-      fill_in("subscription_bill_address_attributes_zipcode", with: "11111")
 
       fill_in("subscription_ship_address_attributes_address1", with: "updated address 1")
-      fill_in("subscription_ship_address_attributes_address2", with: "updated address 2")
-      fill_in("subscription_ship_address_attributes_city", with: "updated city")
-      fill_in("subscription_ship_address_attributes_zipcode", with: "11111")
 
       click_button("Update")
 
       expect(page).to have_field("subscription_bill_address_attributes_address1", with: "updated address 1")
-      expect(page).to have_field("subscription_bill_address_attributes_address2", with: "updated address 2")
-      expect(page).to have_field("subscription_bill_address_attributes_city", with: "updated city")
-      expect(page).to have_field("subscription_bill_address_attributes_zipcode", with: "11111")
 
       expect(page).to have_field("subscription_ship_address_attributes_address1", with: "updated address 1")
-      expect(page).to have_field("subscription_ship_address_attributes_address2", with: "updated address 2")
-      expect(page).to have_field("subscription_ship_address_attributes_city", with: "updated city")
-      expect(page).to have_field("subscription_ship_address_attributes_zipcode", with: "11111")
     end
 
   end

--- a/spec/requests/admin/subscription_spec.rb
+++ b/spec/requests/admin/subscription_spec.rb
@@ -10,4 +10,43 @@ feature 'Subscription' do
     end
   end
 
+  context "updating subscriptions" do
+    let(:order) {
+      order = create(:completed_order_with_totals, bill_address: address, ship_address: address)
+      order.line_items << create(:line_item, variant: product.master, interval: 2)
+     }
+    before do
+      product = FactoryGirl.create(:subscribable_product)
+      order = FactoryGirl.create(:completed_order_with_totals)
+      order.line_items << create(:line_item, variant: product.master, interval: 2)
+      CreateSubscriptionJob.new.perform(order.id)
+    end
+
+    scenario "can update a subscriptions address" do
+      visit spree.admin_path
+      click_link "Subscriptions"
+      click_link("Edit", visible: false)
+
+      fill_in("subscription_bill_address_attributes_address1", with: "updated address 1")
+      fill_in("subscription_bill_address_attributes_address2", with: "updated address 2")
+      fill_in("subscription_bill_address_attributes_city", with: "updated city")
+      fill_in("subscription_bill_address_attributes_zipcode", with: "11111")
+
+      fill_in("subscription_ship_address_attributes_address1", with: "updated address 1")
+      fill_in("subscription_ship_address_attributes_address2", with: "updated address 2")
+      fill_in("subscription_ship_address_attributes_city", with: "updated city")
+      fill_in("subscription_ship_address_attributes_zipcode", with: "11111")
+
+      click_button("Update")
+
+      save_and_open_page
+
+      expect(page).to have_content("updated address 1")
+      expect(page).to have_content("pdated address 2")
+      expect(page).to have_content("updated city")
+      expect(page).to have_content("11111")
+    end
+
+  end
+
 end

--- a/spec/requests/admin/subscription_spec.rb
+++ b/spec/requests/admin/subscription_spec.rb
@@ -39,12 +39,15 @@ feature 'Subscription' do
 
       click_button("Update")
 
-      save_and_open_page
+      expect(page).to have_field("subscription_bill_address_attributes_address1", with: "updated address 1")
+      expect(page).to have_field("subscription_bill_address_attributes_address2", with: "updated address 2")
+      expect(page).to have_field("subscription_bill_address_attributes_city", with: "updated city")
+      expect(page).to have_field("subscription_bill_address_attributes_zipcode", with: "11111")
 
-      expect(page).to have_content("updated address 1")
-      expect(page).to have_content("pdated address 2")
-      expect(page).to have_content("updated city")
-      expect(page).to have_content("11111")
+      expect(page).to have_field("subscription_ship_address_attributes_address1", with: "updated address 1")
+      expect(page).to have_field("subscription_ship_address_attributes_address2", with: "updated address 2")
+      expect(page).to have_field("subscription_ship_address_attributes_city", with: "updated city")
+      expect(page).to have_field("subscription_ship_address_attributes_zipcode", with: "11111")
     end
 
   end

--- a/spec/services/update_subscription_address_spec.rb
+++ b/spec/services/update_subscription_address_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe UpdateSubscriptionAddress do
+
+  context "when updating a subscription" do
+    let(:user) { create(:user) }
+    let(:old_address) { create(:subscription_address, address1: "Old Address", user: user) }
+    let(:subscription) { create(:subscription, ship_address: old_address, bill_address: old_address, user: user) }
+
+    before do
+      @new_address = build_address_params(old_address)
+      @new_address[:address1] = "New Address"
+    end
+
+    it "admin users are able to update only the ship address" do
+      subscription_params = {
+        "interval": subscription.interval,
+        "email": subscription.email,
+        "ship_address_attributes": @new_address,
+        "bill_address_attributes": old_address
+      }
+      UpdateSubscriptionAddress.new.update_address(subscription, subscription_params)
+
+      updated_ship_address_params = build_address_params(subscription.ship_address)
+
+      expect(subscription.ship_address.user_id).to eq(subscription.user_id)
+      expect(updated_ship_address_params).to eq(@new_address)
+
+      expect(subscription.bill_address).to eq(old_address)
+    end
+
+    it "admin users are able to update only the bill address" do
+      subscription_params = {
+        "interval": subscription.interval,
+        "email": subscription.email,
+        "ship_address_attributes": old_address,
+        "bill_address_attributes": @new_address
+      }
+      UpdateSubscriptionAddress.new.update_address(subscription, subscription_params)
+
+      updated_bill_address_params = build_address_params(subscription.bill_address)
+
+      expect(subscription.bill_address.user_id).to eq(subscription.user_id)
+      expect(updated_bill_address_params).to eq(@new_address)
+
+      expect(subscription.ship_address).to eq(old_address)
+    end
+
+    it "admin users are able to update both the ship and bill addresses" do
+      subscription_params = {
+        "interval": subscription.interval,
+        "email": subscription.email,
+        "ship_address_attributes": @new_address,
+        "bill_address_attributes": @new_address
+      }
+      UpdateSubscriptionAddress.new.update_address(subscription, subscription_params)
+
+      updated_ship_address_params = build_address_params(subscription.ship_address)
+      updated_bill_address_params = build_address_params(subscription.bill_address)
+
+      expect(subscription.ship_address.user_id).to eq(subscription.user_id)
+      expect(updated_ship_address_params).to eq(@new_address)
+
+      expect(subscription.bill_address.user_id).to eq(subscription.user_id)
+      expect(updated_bill_address_params).to eq(@new_address)
+
+    end
+  end
+
+  def build_address_params(address)
+    address = {
+      firstname: address.firstname,
+      lastname: address.lastname,
+      address1: address.address1,
+      address2: address.address2,
+      zipcode: address.zipcode,
+      country_id: address.country_id,
+      state_id: address.state_id,
+      phone: address.phone
+    }
+  end
+
+end

--- a/spec/services/update_subscription_address_spec.rb
+++ b/spec/services/update_subscription_address_spec.rb
@@ -10,6 +10,9 @@ describe UpdateSubscriptionAddress do
     before do
       @new_address = build_address_params(old_address)
       @new_address[:address1] = "New Address"
+      @new_address[:address2] = "New Address 2"
+      @new_address[:city] = "Updated City"
+      @new_address[:zipcode] = "11111"
     end
 
     it "admin users are able to update only the ship address" do
@@ -73,6 +76,7 @@ describe UpdateSubscriptionAddress do
       lastname: address.lastname,
       address1: address.address1,
       address2: address.address2,
+      city: address.city,
       zipcode: address.zipcode,
       country_id: address.country_id,
       state_id: address.state_id,


### PR DESCRIPTION
@aamyot 
admin users are now able to update a subscriptions ship/bill address and a success/error message is flashed.

because addresses in solidus are read only (also the reason why update wasn't working in v2), i tried a few different things to update the address, most notably duplicating the attributes and merging them like they are done so in a few other places within this extension. however this doesn't work for existing subscriptions because a subscription only has one associated ship address and bill address and there was an issue with the primary key. using update_columns was the easiest/most straightforward way i could accomplish updates. open to other suggestions.

i also added a request spec scenario under subscriptions_spec to exercise to functionality within this extension.