### PR TITLE
save store id when creating next order during subscription renewal

### DIFF
--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -134,7 +134,8 @@ module Spree
         repeat_order: true,
         bill_address: Spree::Address.new(bill_address.dup.attributes.except(*non_existing_attributes)),
         ship_address: Spree::Address.new(ship_address.dup.attributes.except(*non_existing_attributes)),
-        channel: 'subscription'
+        channel: 'subscription',
+        store: Spree::Store.current
       )
       created_order.update_column(:email, email) if email
       created_order


### PR DESCRIPTION
@sherryson @aamyot 

store id needs to be stored now in orders.

cc @bryanmtl 