### PR TITLE
Fix/intl renewal

### DIFF
--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -3,7 +3,7 @@ module Spree
     include SubscriptionStateMachine
 
     has_many :subscription_items, dependent: :destroy, inverse_of: :subscription
-    has_and_belongs_to_many :orders, join_table: :spree_orders_subscriptions
+    has_and_belongs_to_many :orders, join_table: :spree_orders_subscriptions, after_add: :set_email
     belongs_to :user
     belongs_to :credit_card
     alias_attribute :items, :subscription_items
@@ -125,10 +125,6 @@ module Spree
         store: last_completed_order.store,
         currency: last_completed_order.currency
       )
-      # use the subscription's email if present.
-      # we are doing it here because the order's callback associate_user! will
-      # override the order's email even if we set it during creation
-      created_order.update_column(:email, email) if email
       created_order
     end
 
@@ -239,5 +235,9 @@ module Spree
         last_renewal_at.advance(calc_next_renewal_date))
     end
 
+    def set_email(new_order)
+      # use the subscription's email if present vs last order's
+      new_order.update_column(:email, email) if email
+    end
   end
 end

--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -123,7 +123,8 @@ module Spree
         bill_address: Spree::Address.new(bill_address.dup.attributes.except(*non_existing_attributes)),
         ship_address: Spree::Address.new(ship_address.dup.attributes.except(*non_existing_attributes)),
         channel: 'subscription',
-        store: Spree::Store.default
+        store: last_completed_order.store,
+        currency: last_completed_order.currency
       )
       created_order.update_column(:email, email) if email
       created_order

--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -115,7 +115,6 @@ module Spree
     def create_next_order!
       # just keeping safe
       non_existing_attributes = Spree::SubscriptionAddress.dup.attribute_names - Spree::Address.attribute_names
-
       # use subscription's addresses for the new order and email
       created_order = orders.create!(
         user: last_completed_order.user,
@@ -126,6 +125,9 @@ module Spree
         store: last_completed_order.store,
         currency: last_completed_order.currency
       )
+      # use the subscription's email if present.
+      # we are doing it here because the order's callback associate_user! will
+      # override the order's email even if we set it during creation
       created_order.update_column(:email, email) if email
       created_order
     end

--- a/app/views/spree/admin/subscriptions/_sidebar.html.erb
+++ b/app/views/spree/admin/subscriptions/_sidebar.html.erb
@@ -50,6 +50,8 @@
     <% else %>
       <dd><%= link_to Spree.t(:create), credit_card_admin_subscription_path(@subscription) %></dd>
     <% end %>
+    <dt>Currency</dt>
+    <dd class="<%= @subscription.last_order.currency.downcase %>">
     <dt>Last updated</dt>
     <dd><%= l(@subscription.updated_at, format: :long) %></dd>
   </dt>

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -75,7 +75,8 @@
        <col style="width: 18%;">
        <col style="width: 15%;">
        <col style="width: 3%;">
-       <col style="width: 9%;">
+       <col style="width: 6%;">
+       <col style="width: 3%;">
        <col style="width: 9%;">
     </colgroup>
     <thead>
@@ -87,6 +88,7 @@
         <th>User</th>
         <th>Skip</th>
         <th>Renew Date</th>
+        <th>Cur</th>
         <th data-hook="admin_subscriptions_index_header_actions" class="actions"></th>
       </tr>
     </thead>
@@ -118,6 +120,7 @@
         </td>
         <td class="align-center"><%= subscription.skip_order_at ? 'Yes' : '' if subscription.can_renew? %></td>
         <td class="align-center"><%= l(subscription.next_shipment_date, format: :subscription_date_format) if subscription.can_renew? %></td>
+        <td class="align-center center-flags <%= subscription.last_order.currency.downcase %>"></td>
         <td class='actions align-center' data-hook="admin_subscriptions_index_row_actions">
           <%=
             link_to_with_icon 'edit', 'Edit', edit_admin_subscription_path(subscription), no_text: true

--- a/spec/models/spree/subscription_spec.rb
+++ b/spec/models/spree/subscription_spec.rb
@@ -198,6 +198,24 @@ describe Spree::Subscription do
     end
   end
 
+  context '#create_next_order!' do
+    let(:second_store) { create(:store) }
+
+    before do
+      create_completed_subscription_order
+
+      subscription.last_order.update_column(:currency, 'CAD')
+      subscription.last_order.update_column(:store_id, second_store.id)
+    end
+
+    it "has the last order's currency and store" do
+      subscription.create_next_order!
+
+      expect(subscription.last_order.currency).to eq 'CAD'
+      expect(subscription.last_order.store_id).to eq second_store.id
+    end
+  end
+
   describe "can_renew?" do
     let(:subscription) { FactoryGirl.create(:subscription) }
 


### PR DESCRIPTION
@hugobast @sherryson 

this is ready for CR. the problem earlier is renewal isn't working for Canadian subscriptions because the order's currency is being set to USD. 

The changes here will set the subsequent orders to follow the last completed order's currency and store id.

I also surfaced the currency in the admin subscription listing page, similar to our admin orders listing.